### PR TITLE
feat: attendance scheduling to c#

### DIFF
--- a/TeamAttendance.Tests/TeamAttendance.Tests.csproj
+++ b/TeamAttendance.Tests/TeamAttendance.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TeamAttendance\TeamAttendance.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TeamAttendance.Tests/UserTests.cs
+++ b/TeamAttendance.Tests/UserTests.cs
@@ -1,0 +1,48 @@
+using System;
+using TeamAttendance;
+using Xunit;
+
+namespace TeamAttendance.Tests;
+
+public class UserTests
+{
+    [Fact]
+    public void CreateUserStartsWithNoSchedule()
+    {
+        var user = new User("u1", "Alice");
+        var day = new DateOnly(2025, 1, 1);
+        var schedule = user.GetSchedule(day, day);
+        Assert.Null(schedule[day]);
+    }
+
+    [Fact]
+    public void ScheduleDayUpdatesStatus()
+    {
+        var user = new User("u1", "Alice");
+        var day = new DateOnly(2025, 1, 2);
+        user.ScheduleDay(day, Status.Office);
+        Assert.Equal(Status.Office, user.GetSchedule(day, day)[day]);
+    }
+
+    [Fact]
+    public void RequestDayOffPreventsRescheduling()
+    {
+        var user = new User("u1", "Alice");
+        var day = new DateOnly(2025, 1, 3);
+        user.RequestDayOff(day);
+        Assert.Throws<InvalidOperationException>(() => user.ScheduleDay(day, Status.Home));
+    }
+
+    [Fact]
+    public void GetScheduleReturnsRange()
+    {
+        var user = new User("u1", "Alice");
+        var day1 = new DateOnly(2025, 1, 4);
+        var day2 = new DateOnly(2025, 1, 5);
+        user.ScheduleDay(day1, Status.Home);
+        user.RequestDayOff(day2);
+        var schedule = user.GetSchedule(day1, day2);
+        Assert.Equal(Status.Home, schedule[day1]);
+        Assert.Equal(Status.Off, schedule[day2]);
+    }
+}

--- a/TeamAttendance.sln
+++ b/TeamAttendance.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeamAttendance", "TeamAttendance\TeamAttendance.csproj", "{13CB6659-5DAE-4F55-B7C0-6373D7D1FBDD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeamAttendance.Tests", "TeamAttendance.Tests\TeamAttendance.Tests.csproj", "{7DD8503C-000B-4278-BD20-5E33B868ADC9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{13CB6659-5DAE-4F55-B7C0-6373D7D1FBDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13CB6659-5DAE-4F55-B7C0-6373D7D1FBDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13CB6659-5DAE-4F55-B7C0-6373D7D1FBDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13CB6659-5DAE-4F55-B7C0-6373D7D1FBDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DD8503C-000B-4278-BD20-5E33B868ADC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DD8503C-000B-4278-BD20-5E33B868ADC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DD8503C-000B-4278-BD20-5E33B868ADC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DD8503C-000B-4278-BD20-5E33B868ADC9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/TeamAttendance/TeamAttendance.csproj
+++ b/TeamAttendance/TeamAttendance.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TeamAttendance/User.cs
+++ b/TeamAttendance/User.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace TeamAttendance;
+
+public enum Status
+{
+    Office,
+    Home,
+    Off
+}
+
+public class User
+{
+    public string UserId { get; }
+    public string Name { get; }
+    private readonly Dictionary<DateOnly, Status> _schedule = new();
+
+    public User(string userId, string name)
+    {
+        UserId = userId;
+        Name = name;
+    }
+
+    public void ScheduleDay(DateOnly day, Status status)
+    {
+        if (_schedule.ContainsKey(day))
+            throw new InvalidOperationException($"Day {day} already scheduled as {_schedule[day]}");
+        _schedule[day] = status;
+    }
+
+    public void RequestDayOff(DateOnly day)
+    {
+        ScheduleDay(day, Status.Off);
+    }
+
+    public IDictionary<DateOnly, Status?> GetSchedule(DateOnly start, DateOnly end)
+    {
+        if (end < start)
+            throw new ArgumentException("end must be on or after start", nameof(end));
+
+        var result = new Dictionary<DateOnly, Status?>();
+        var current = start;
+        while (current <= end)
+        {
+            result[current] = _schedule.TryGetValue(current, out var status) ? status : null;
+            current = current.AddDays(1);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- attendance module with C# library using `Status` enum and `User` aggregate
- include xUnit tests verifying scheduling, day-off requests, and range retrieval

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bbe7ce4c832c97c7aec33e7f988a